### PR TITLE
Replace weapon macros with new PF2e weapon style

### DIFF
--- a/scripts/items/consumable.js
+++ b/scripts/items/consumable.js
@@ -41,35 +41,7 @@ export async function postConsumableWeapon(title, header, ...choices) {
     if (!actor || !item) {
         return;
     }
-
-
-    if (item.isEquipped) {
-        // The weapon is already equipped, so just roll the action macro
-        game.pf2e.rollActionMacro({ actorUUID: "Actor:" + updatedActor.id, type: "strike", itemId: item.id, slug: item.slug });
-    } else {
-        // The weapon isn't drawn, so draw it now
-        const action = actor.system.actions
-            .find(action => action.item.id === item.id)
-            ?.auxiliaryActions
-            ?.find(action => action.carryType === "held");
-        if (action) {
-            await action.execute();
-        }
-    }
-
-    setTimeout(
-        () => {
-            // Now we've drawn the weapon, we need to find the drawn version and roll its action macro
-            const updatedActor = getControlledActor();
-            const weapon = updatedActor.itemTypes.weapon.find(weapon => weapon.isEquipped && weapon.slug == item.slug && isInfused(weapon) === isInfused(item));
-            if (!weapon) {
-                return;
-            }
-
-            game.pf2e.rollActionMacro({ actorUUID: "Actor:" + updatedActor.id, type: "strike", itemId: weapon.id, slug: weapon.slug });
-        },
-        250
-    );
+    game.pf2e.rollActionMacro({ actorUUID: "Actor." + actor.id, type: "strike", itemId: item.id, slug: item.slug });
 }
 
 /**

--- a/scripts/items/consumable.js
+++ b/scripts/items/consumable.js
@@ -45,7 +45,7 @@ export async function postConsumableWeapon(title, header, ...choices) {
 
     if (item.isEquipped) {
         // The weapon is already equipped, so just roll the action macro
-        game.pf2e.rollActionMacro(item.id, 0, item.slug);
+        game.pf2e.rollActionMacro({ actorUUID: "Actor:" + updatedActor.id, type: "strike", itemId: item.id, slug: item.slug });
     } else {
         // The weapon isn't drawn, so draw it now
         const action = actor.system.actions
@@ -66,7 +66,7 @@ export async function postConsumableWeapon(title, header, ...choices) {
                 return;
             }
 
-            game.pf2e.rollActionMacro(weapon.id, 0, weapon.slug);
+            game.pf2e.rollActionMacro({ actorUUID: "Actor:" + updatedActor.id, type: "strike", itemId: weapon.id, slug: weapon.slug });
         },
         250
     );


### PR DESCRIPTION
This PR fixes https://github.com/JDCalvert/pf2e-convenient-consumables/issues/3

It also makes a more opinionated change.  In the latest iteration of the PF2e system, a weapon macro can be designed to post up a draw/sheathe option as well as the full multi-attack window.  This is the typical behavior of dragging something like alchemist fire to the macro bar.

As a result the manual drawing update is not required - a user cannot throw an item without drawing it anyway, and the reliance on the PF2e core behavior is more future-proofed.